### PR TITLE
add :crypto as extra_application

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,7 @@ defmodule ABNF.Mixfile do
   end
 
   def application do
-    [applications: [:logger]]
+    [extra_applications: [:logger, :crypto]]
   end
 
   defp deps do


### PR DESCRIPTION
This is needed to handle elixir 1.11.x warnings. Also use `extra_applications` and not `applications` since is the correct way to specify app deps.